### PR TITLE
oprava pokud api vrati pouze jeden porad

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.dmd-czech.stream"
        name="Stream TV Archiv"
-       version="1.2.4"
+       version="1.2.5"
        provider-name="Jiri Vyhnalek">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+2016-03-13 [1.2.5]
+  * Oprava - sekce Pohadky nelze otevrit pokud API vrati pouze jeden porad.
 2016-01-30 [1.2.4]
   * V popise videa sa odstrania/nahradia HTML znacky za formatovacie znacky podporovane v Kodi.
   * Doplnena moznost vyberu inej kvality videa z kontextoveho menu.

--- a/default.py
+++ b/default.py
@@ -149,6 +149,9 @@ def listContent():
 
 def listShows(url):
     data = getJsonDataFromUrl(url)
+    if type(data[u'_embedded'][u'stream:show']) is dict:
+        data[u'_embedded'][u'stream:show'] = [data[u'_embedded'][u'stream:show']]
+
     for item in data[u'_embedded'][u'stream:show']:
         if u'stream:backward' in item[u'_links']:
             link = __baseurl__+item[u'_links'][u'stream:backward'][u'href']


### PR DESCRIPTION
API vraci porady jako 'list of dicts'. Pokud je na dotaz k dispozici jenom jeden porad, tak se vrati primo dict toho jednoho poradu. Dal jsem ten jeden dict do listu, aby se to spravne zpracovalo.
